### PR TITLE
Draft: Add Perlmutter GPU configuration

### DIFF
--- a/0001-add-ofi.patch
+++ b/0001-add-ofi.patch
@@ -1,0 +1,34 @@
+From 32bef76b3d7e66ffb78a4b1331a2d88b3eb4f3d9 Mon Sep 17 00:00:00 2001
+From: Daniel Margala <danielmargala@lbl.gov>
+Date: Sat, 9 Jul 2022 15:09:40 -0700
+Subject: [PATCH] add ofi
+
+---
+ install.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/install.py b/install.py
+index d2f1181..ef93383 100755
+--- a/install.py
++++ b/install.py
+@@ -402,7 +402,7 @@ calls into NCCL either directly or through some other Legate library.
+             + extra_flags
+             + (["BOUNDS_CHECKS=1"] if check_bounds else [])
+             + (["GASNET=%s" % gasnet_dir] if gasnet_dir is not None else [])
+-            + (["CONDUIT=%s" % conduit] if conduit is not None else [])
++            + (["CONDUIT=%s" % conduit.split("-")[0]] if conduit is not None else [])
+             + (["CUDA=%s" % cuda_dir] if cuda_dir is not None else [])
+         )
+ 
+@@ -959,7 +959,7 @@ def driver():
+         dest="conduit",
+         action="store",
+         required=False,
+-        choices=["ibv", "ucx", "aries", "mpi", "udp"],
++        choices=["ibv", "ucx", "aries", "mpi", "udp", "ofi-slingshot10", "ofi-slingshot11"],
+         default=os.environ.get("CONDUIT"),
+         help="Build Legate with specified GASNet conduit.",
+     )
+-- 
+2.34.1
+

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,10 @@ detect_platform && set_build_vars
 
 # Run appropriate build command for the target library
 if [[ -d "legate/core" ]]; then
+    if [[ "$PLATFORM" == perlmutter ]]; then
+        export CROSS_CONFIGURE=""
+        export GASNET_EXTRA_CONFIGURE_ARGS="--with-mpi-cc=cc"
+    fi
     if [[ "$CONDUIT" == ibv ]]; then
         export GASNET_EXTRA_CONFIGURE_ARGS="--enable-ibv-multirail --with-ibv-max-hcas=$NUM_NICS"
     fi

--- a/common.sh
+++ b/common.sh
@@ -20,8 +20,8 @@ function detect_platform {
         return
     elif command -v dnsdomainname &> /dev/null && [[ "$(dnsdomainname)" == *"summit"* ]]; then
         export PLATFORM=summit
-    elif [[ "$(uname -n)" == "cori"* ]]; then
-        export PLATFORM=cori
+    elif [[ -n "${NERSC_HOST+x}" ]]; then
+        export PLATFORM="$NERSC_HOST"
     elif [[ "$(uname -n)" == *"daint"* ]]; then
         export PLATFORM=pizdaint
     elif [[ "$(uname -n)" == *"sapling"* ]]; then
@@ -45,6 +45,11 @@ function set_build_vars {
         export NUM_NICS=4
         export CUDA_HOME="$CUDA_DIR"
         export GPU_ARCH=volta
+    elif [[ "$PLATFORM" == perlmutter ]]; then
+        export CONDUIT=ofi-slingshot11
+        export NUM_NICS=4
+        # CUDA_HOME is already set (by module)
+        export GPU_ARCH=ampere
     elif [[ "$PLATFORM" == cori ]]; then
         export CONDUIT=ibv
         export NUM_NICS=4

--- a/legate.slurm
+++ b/legate.slurm
@@ -16,7 +16,8 @@
 #
 
 set -u
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# on perlmutter, this does not have the desired effect
+# SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$SCRIPT_DIR/common.sh"
 
 echo "Job ID: $SLURM_JOB_ID"

--- a/setup_conda.sh
+++ b/setup_conda.sh
@@ -24,6 +24,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [[ $# -ge 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
     echo "Usage: $(basename "${BASH_SOURCE[0]}") [extra conda packages]"
     echo "Arguments read from the environment:"
+    echo "  CONDA_USE_PREFIX : interpret CONDA_ENV as a prefix instead of name"
     echo "  CONDA_ENV : name of conda environment to create (default: legate)"
     echo "  CONDA_ROOT : where to install conda (if not already installed)"
     echo "  CUDA_VER : CUDA runtime version to request from conda (if applicable)"
@@ -80,6 +81,7 @@ if conda info --envs | grep -q "^$CONDA_ENV "; then
     echo "Error: Conda environment $CONDA_ENV already exists" 1>&2
     exit 1
 fi
+
 if [[ "$(uname -s)" == Darwin ]]; then
     SED="sed -i ''"
 else
@@ -97,7 +99,11 @@ fi
 for PACKAGE in "$@"; do
     echo "  - $PACKAGE" >> "$YML_FILE"
 done
-conda env create -n "$CONDA_ENV" -f "$YML_FILE"
+if [[ -n "${CONDA_USE_PREFIX+x}" ]]; then
+    conda env create -p "$CONDA_ENV" -f "$YML_FILE"
+else
+    conda env create -n "$CONDA_ENV" -f "$YML_FILE"
+fi
 rm "$YML_FILE"
 
 # Copy conda activation scripts (these set various paths)


### PR DESCRIPTION
This PR adds configuration details to build legate.core and cunumeric for Perlmutter SS11 GPU nodes. I'm not sure everything is configured optimally but it seems the result functional at least. Are there any tests I could run to sanity check multi-GPU and multi-node performance?

Build instructions:

```
# from a perlmutter login node
module load python
module load cudatoolkit
module load craype-accel-nvidia80
module load cray-pmi

# I modified setup_conda.sh to install the environment using a prefix (-p) instead of a name (-n)
PREFIX=/global/common/software/dasrepo/dmargala/cunumeric-ofi
PYTHON_VER=3.10 CONDA_USE_PREFIX=1 CONDA_ENV=$PREFIX ./setup_conda.sh

conda activate $PREFIX
export LEGATE_DIR=$PREFIX
export PLATFORM=perlmutter
export CC=cc
export CXX=CC
export FC=ftn

cd ../legate.core
# apply patch to build gasnet with ss11 libfabric
patch ./install.py ../quickstart/0001-add-ofi.patch
../quickstart/build.sh

cd ../cunumeric
../quickstart/build.sh
```

Runtime usage:

```
# from a perlmutter login node
module load python
module load cudatoolkit
PREFIX=/global/common/software/dasrepo/dmargala/cunumeric-ofi
conda activate $PREFIX
export LEGATE_DIR=$PREFIX
export PLATFORM=perlmutter
export ACCOUNT=nstaff

cd cunumeric/
# I had to bypass the system libstdc++.so which is missing some recent GLIBCXX version required by some python packages:
# ImportError: /opt/cray/pe/gcc-libs/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /global/common/software/dasrepo/dmargala/cunumeric-ofi/lib/python3.10/site-packages/pyarrow/../../../libarrow.so.800)
LD_PRELOAD=$PREFIX/lib/libstdc++.so ../quickstart/run.sh 2 examples/gemm.py -n 20000 --gpus 4
```

Output from test run:

```
> LD_PRELOAD=$PREFIX/lib/libstdc++.so ../quickstart/run.sh 2 examples/gemm.py -n 20000 --gpus 4
Redirecting stdout, stderr and logs to /ascratch/sd/d/dmargala/2022/07/11/094245
Submitted: sbatch -q regular_ss11 -o /ascratch/sd/d/dmargala/2022/07/11/094245/out.txt --ntasks-per-node 1 -c 128 --gpus-per-task 4 -J legate -A nstaff -t 60 -N 2 -C gpu /global/homes/d/dmargala/test-cunumeric/quickstart/legate.slurm /global/common/software/dasrepo/dmargala/cunumeric-ofi/bin/legate --launcher srun --numamem 48000 --omps 4 --ompthreads 15 --cpus 1 --sysmem 256 --gpus 4 --fbmem 36250 --verbose --log-to-file --nodes 2 --ranks-per-node 1 examples/gemm.py -n 20000 --gpus 4
Submitted batch job 46598
Waiting for job to start & piping stdout/stderr
Press Ctrl-C anytime to exit (job will still run)
Job started
Job ID: 46598
Submitted from: /global/homes/d/dmargala/test-cunumeric/cunumeric
Started on: Mon 11 Jul 2022 09:42:46 AM PDT
Running on: nid[001012-001013]
Command: /global/common/software/dasrepo/dmargala/cunumeric-ofi/bin/legate --launcher srun --numamem 48000 --omps 4 --ompthreads 15 --cpus 1 --sysmem 256 --gpus 4 --fbmem 36250 --verbose --log-to-file --nodes 2 --ranks-per-node 1 examples/gemm.py -n 20000 --gpus 4 --logdir /ascratch/sd/d/dmargala/2022/07/11/094245
WARNING: Found multiple python supports in your Legion installation.
Using the following one: /global/common/software/dasrepo/dmargala/cunumeric-ofi/lib/python3.10/site-packages
Running: srun -n 2 --ntasks-per-node 1 /global/common/software/dasrepo/dmargala/cunumeric-ofi/bin/legion_python -ll:py 1 -lg:local 0 -ll:gpu 4 -cuda:skipbusy -ll:ocpu 4 -ll:othr 15 -ll:onuma 1 -ll:util 2 -ll:bgwork 2 -ll:csize 256 -ll:nsize 48000 -ll:fsize 36250 -ll:zsize 32 -level openmp=5,gpu=5 -logfile /ascratch/sd/d/dmargala/2022/07/11/094245/legate_%.log -lg:eager_alloc_percentage 50 examples/gemm.py -n 20000
WARNING: Using GASNet's ofi-conduit, which exists for portability convenience.
WARNING: This system appears to contain recognized network hardware: Cray Gemini (XE and XK) or Aries (XC)
WARNING: which is supported by a GASNet native conduit, although
WARNING: it was not detected at configure time (missing drivers?)
WARNING: You should *really* use the high-performance native GASNet conduit
WARNING: if communication performance is at all important in this program run.
 WARNING: ofi-conduit is experimental and should not be used for
          performance measurements.
          Please see `ofi-conduit/README` for more details.
Problem Size:     M=20000 N=20000 K=20000
Total Iterations: 100
Total Flops:      15999.6 GFLOPS/iter
Total Size:       4800.0 MB
Elapsed Time:     10065.18 ms
Average GEMM:     100.65180000000001 ms
FLOPS/s:          158959.89937586806 GFLOPS/s
Job finished: Mon 11 Jul 2022 09:43:03 AM PDT
```